### PR TITLE
WindowChecker fix

### DIFF
--- a/core/src/main/java/io/durg/kirtimukh/throttling/ThrottlingController.java
+++ b/core/src/main/java/io/durg/kirtimukh/throttling/ThrottlingController.java
@@ -79,7 +79,8 @@ public class ThrottlingController {
     private WindowChecker getWindowChecker(final ThrottlingKey throttlingKey) {
         final String configKey = throttlingKey.getConfigName();
         if (!windowCheckerMap.containsKey(configKey)) {
-            windowCheckerMap.put(configKey, WindowCheckerUtils.getWindowChecker(throttlingKey, defaultStrategyConfig));
+            windowCheckerMap.put(configKey, WindowCheckerUtils.getWindowChecker(throttlingKey, commandStrategyConfigs
+                    .getOrDefault(configKey, defaultStrategyConfig)));
         }
 
         return windowCheckerMap.get(configKey);

--- a/core/src/test/java/io/durg/kirtimukh/throttling/ThrottlingControllerTest.java
+++ b/core/src/test/java/io/durg/kirtimukh/throttling/ThrottlingControllerTest.java
@@ -119,11 +119,29 @@ class ThrottlingControllerTest {
         throttlingController.register(ThrottlingKey.builder()
                 .bucketName("testCustomBucket")
                 .build());
-        LeakyBucketWindowChecker testCustomBucket = (LeakyBucketWindowChecker) throttlingController
-                .getInfo()
-                .get("testCustomBucket");
         Assertions.assertNotNull(throttlingController.getInfo());
         Assertions.assertNotNull(throttlingController.getInfo().get("testCustomBucket"));
-        Assertions.assertEquals(3, testCustomBucket.getWindow().getThreshold());
+        Assertions.assertEquals(3, ((LeakyBucketWindowChecker) throttlingController
+                .getInfo()
+                .get("testCustomBucket"))
+                .getWindow()
+                .getThreshold());
+    }
+
+    @Test
+    void registerCustomWithDefaultStrategyBucket() {
+        throttlingController.register(ThrottlingKey.builder()
+                .bucketName("testCustomBucketDefault")
+                .build());
+        LeakyBucketWindowChecker testCustomBucket = (LeakyBucketWindowChecker) throttlingController
+                .getInfo()
+                .get("testCustomBucketDefault");
+        Assertions.assertNotNull(throttlingController.getInfo());
+        Assertions.assertNotNull(throttlingController.getInfo().get("testCustomBucketDefault"));
+        Assertions.assertEquals(1, ((LeakyBucketWindowChecker) throttlingController
+                .getInfo()
+                .get("testCustomBucketDefault"))
+                .getWindow()
+                .getThreshold());
     }
 }

--- a/core/src/test/java/io/durg/kirtimukh/throttling/ThrottlingControllerTest.java
+++ b/core/src/test/java/io/durg/kirtimukh/throttling/ThrottlingControllerTest.java
@@ -20,6 +20,7 @@ import io.durg.kirtimukh.throttling.config.ThrottlingStrategyConfig;
 import io.durg.kirtimukh.throttling.config.impl.LeakyBucketThrottlingStrategyConfig;
 import io.durg.kirtimukh.throttling.config.impl.QuotaThrottlingStrategyConfig;
 import io.durg.kirtimukh.throttling.enums.ThrottlingWindowUnit;
+import io.durg.kirtimukh.throttling.window.impl.LeakyBucketWindowChecker;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -48,6 +49,9 @@ class ThrottlingControllerTest {
         strategyConfigs.put("ThrottlingControllerTest.testPriorityBucket", QuotaThrottlingStrategyConfig.builder()
                 .unit(ThrottlingWindowUnit.MINUTE)
                 .threshold(1)
+                .build());
+        strategyConfigs.put("testCustomBucket", LeakyBucketThrottlingStrategyConfig.builder()
+                .threshold(3)
                 .build());
         throttlingController = ThrottlingController.builder()
                 .defaultConfig(LeakyBucketThrottlingStrategyConfig.builder()
@@ -108,5 +112,18 @@ class ThrottlingControllerTest {
                 .build());
         Assertions.assertNotNull(throttlingController.getInfo());
         Assertions.assertNotNull(throttlingController.getInfo().get("ThrottlingControllerTest.testPriorityBucket"));
+    }
+
+    @Test
+    void registerCustomBucket() {
+        throttlingController.register(ThrottlingKey.builder()
+                .bucketName("testCustomBucket")
+                .build());
+        LeakyBucketWindowChecker testCustomBucket = (LeakyBucketWindowChecker) throttlingController
+                .getInfo()
+                .get("testCustomBucket");
+        Assertions.assertNotNull(throttlingController.getInfo());
+        Assertions.assertNotNull(throttlingController.getInfo().get("testCustomBucket"));
+        Assertions.assertEquals(3, testCustomBucket.getWindow().getThreshold());
     }
 }


### PR DESCRIPTION
Fixed getWindowChecker to use commandStraetgyConfig if bucket/commandKey is present in config